### PR TITLE
Enable more compiler errors

### DIFF
--- a/src/BRSRC13/CMakeLists.txt
+++ b/src/BRSRC13/CMakeLists.txt
@@ -17,9 +17,13 @@ target_link_libraries(brender PRIVATE harness miniposix SDL2::SDL2)
 if(NOT MSVC)
     target_compile_options(brender PRIVATE
         -g
+        -Wall
+        -Wextra
+        -Werror
         -Wno-return-type
-        -Wno-missing-declarations
-        -Werror=implicit-function-declaration
+        -Wno-unused-variable
+        -Wno-unused-parameter
+        -Wno-sign-compare
     )
     
     target_link_libraries(brender PUBLIC m)

--- a/src/DETHRACE/CMakeLists.txt
+++ b/src/DETHRACE/CMakeLists.txt
@@ -16,9 +16,13 @@ target_link_libraries(dethrace_obj PUBLIC miniposix SDL2::SDL2 smacker harness b
 if(NOT MSVC)
     target_compile_options(dethrace_obj PRIVATE
         -g
+        -Wall
+        -Wextra
+        -Werror
         -Wno-return-type
-        -Wno-missing-declarations
-        -Werror=implicit-function-declaration
+        -Wno-unused-variable
+        -Wno-unused-parameter
+        -Wno-sign-compare
     )
 else()
     target_compile_definitions(dethrace_obj PRIVATE -D_CRT_SECURE_NO_WARNINGS)

--- a/src/DETHRACE/common/car.c
+++ b/src/DETHRACE/common/car.c
@@ -415,7 +415,7 @@ void SetInitialPosition(tRace_info* pThe_race, int pCar_index, int pGrid_index) 
     int start_i;
     int j;
     br_actor* car_actor;
-    br_angle initial_yaw;
+    br_angle initial_yaw = 0;
     br_scalar nearest_y_above;
     br_scalar nearest_y_below;
     br_scalar speed;
@@ -475,7 +475,6 @@ void SetInitialPosition(tRace_info* pThe_race, int pCar_index, int pGrid_index) 
         // initial_yaw[0] = (__int64)(pThe_race->net_starts[start_i].yaw * 182.0444444444445);
         // place_on_grid = 0;
     }
-LABEL_17:
     if (place_on_grid) {
         initial_yaw = (pThe_race->initial_yaw * 182.0444444444445);
         BrMatrix34RotateY(&initial_yaw_matrix, initial_yaw);

--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -155,7 +155,9 @@ void DRPixelmapCleverText2(br_pixelmap* pPixelmap, int pX, int pY, tDR_font* pFo
     len = strlen((char*)pText);
     ch = (unsigned char*)pText;
     if (pX >= 0 && pPixelmap->width >= pRight_edge && pY >= 0 && pY + pFont->height <= pPixelmap->height) {
+        LOG_DEBUG("string %s, %d", pText, len);
         for (i = 0; i < len; i++) {
+            //LOG_DEBUG("%c, %d, %u", *ch, (signed char)*ch, *ch);
             if (*ch < 224) {
                 chr = *ch - pFont->offset;
                 ch_width = pFont->width_table[chr];

--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -155,9 +155,7 @@ void DRPixelmapCleverText2(br_pixelmap* pPixelmap, int pX, int pY, tDR_font* pFo
     len = strlen((char*)pText);
     ch = (unsigned char*)pText;
     if (pX >= 0 && pPixelmap->width >= pRight_edge && pY >= 0 && pY + pFont->height <= pPixelmap->height) {
-        LOG_DEBUG("string %s, %d", pText, len);
         for (i = 0; i < len; i++) {
-            //LOG_DEBUG("%c, %d, %u", *ch, (signed char)*ch, *ch);
             if (*ch < 224) {
                 chr = *ch - pFont->offset;
                 ch_width = pFont->width_table[chr];

--- a/src/DETHRACE/common/displays.c
+++ b/src/DETHRACE/common/displays.c
@@ -516,7 +516,6 @@ void DoHeadups(tU32 pThe_time) {
                     }
                 }
             } else {
-            LABEL_22:
                 ClearHeadup(i);
             }
         }

--- a/src/DETHRACE/common/mainloop.c
+++ b/src/DETHRACE/common/mainloop.c
@@ -202,13 +202,13 @@ void MungeHeadups() {
         DoNetworkHeadups(net_credits);
     } else {
         if (net_credits < 0) {
-            sprintf(the_text, "ø%dú %s", -net_credits, GetMiscString(17));
+            sprintf(the_text, "\xF8%d\xFA %s", -net_credits, GetMiscString(17));
         } else {
-            sprintf(the_text, "ø%dú %s", net_credits, GetMiscString(net_credits < 100000 ? 16 : 47));
+            sprintf(the_text, "\xF8%d\xFA %s", net_credits, GetMiscString(net_credits < 100000 ? 16 : 47));
         }
         ChangeHeadupText(gCredits_won_headup, the_text);
         if (gPedestrians_on) {
-            sprintf(the_text, "ø%dú/%d %s", gProgram_state.peds_killed, gTotal_peds, GetMiscString(18));
+            sprintf(the_text, "\xF8%d\xFA/%d %s", gProgram_state.peds_killed, gTotal_peds, GetMiscString(18));
             ChangeHeadupText(gPed_kill_count_headup, the_text);
         } else {
             ChangeHeadupText(gPed_kill_count_headup, "");
@@ -218,13 +218,13 @@ void MungeHeadups() {
         }
         if (gQueued_wasted_massages_count) {
             if (Flash(150, &gWasted_last_flash, &gWasted_flash_state)) {
-                sprintf(the_text, "ù%s %s", gOpponents[gQueued_wasted_massages[0]].abbrev_name, GetMiscString(46));
+                sprintf(the_text, "\xF9%s %s", gOpponents[gQueued_wasted_massages[0]].abbrev_name, GetMiscString(46));
             } else {
                 sprintf(the_text, " ");
             }
         } else {
             oppo_count = GetCarCount(eVehicle_opponent);
-            sprintf(the_text, "%s ø%dú/%d", GetMiscString(19), oppo_count - NumberOfOpponentsLeft(), oppo_count);
+            sprintf(the_text, "%s \xF8%d\xFA/%d", GetMiscString(19), oppo_count - NumberOfOpponentsLeft(), oppo_count);
         }
         ChangeHeadupText(gCar_kill_count_headup, the_text);
         if (effective_timer > 1199000) {
@@ -232,7 +232,7 @@ void MungeHeadups() {
         }
         TimerString(effective_timer, the_text, 1, 0);
         ChangeHeadupText(gTimer_headup, the_text);
-        sprintf(the_text, "%s ø%dú/%d %s ø%dú/%d", GetMiscString(21), gCheckpoint, gCheckpoint_count, GetMiscString(20), gLap, gTotal_laps);
+        sprintf(the_text, "%s \xF8%d\xFA/%d %s \xF8%d\xFA/%d", GetMiscString(21), gCheckpoint, gCheckpoint_count, GetMiscString(20), gLap, gTotal_laps);
         ChangeHeadupText(gLaps_headup, the_text);
         the_time = GetTotalTime() - gTime_bonus_start;
         switch (gTime_bonus_state) {

--- a/src/DETHRACE/common/mainmenu.c
+++ b/src/DETHRACE/common/mainmenu.c
@@ -489,6 +489,7 @@ int DoVerifyQuit(int pReplace_background) {
     int switched_res;
     int woz_in_race;
 
+    woz_in_race = 0;
     if (gAusterity_mode) {
         return 1;
     }

--- a/src/DETHRACE/common/utility.c
+++ b/src/DETHRACE/common/utility.c
@@ -536,7 +536,6 @@ tU32 GetTotalTime() {
     if (gNet_mode) {
         return PDGetTotalTime();
     }
-    LOG_DEBUG("gLost_time %d", gLost_time);
     return PDGetTotalTime() - gLost_time;
 }
 
@@ -681,17 +680,14 @@ br_pixelmap* GenerateDarkenedShadeTable(int pHeight, br_pixelmap* pPalette, int 
 
 // IDA: void __cdecl PossibleService()
 void PossibleService() {
+    tU32 time;
     static tU32 last_service = 0;
-    // Added >>
-    tU32 current_time;
-    // <<
 
-    current_time = PDGetTotalTime();
-
-    if (current_time - last_service > MIN_SERVICE_INTERVAL && !gProgram_state.racing) {
+    time = PDGetTotalTime();
+    if (time - last_service > MIN_SERVICE_INTERVAL && !gProgram_state.racing) {
         SoundService();
         NetService(gProgram_state.racing);
-        last_service = current_time;
+        last_service = time;
     }
 }
 

--- a/src/S3/CMakeLists.txt
+++ b/src/S3/CMakeLists.txt
@@ -9,9 +9,10 @@ target_link_libraries(s3 PRIVATE)
 if(NOT MSVC)
     target_compile_options(s3 PRIVATE
         -g
-        -Wno-return-type
-        -Wno-missing-declarations
-        -Werror=implicit-function-declaration
+        -Wall
+        -Wextra
+        -Werror
+        -Wno-unused-parameter
     )
 else()
     target_compile_definitions(s3 PRIVATE -D_CRT_SECURE_NO_WARNINGS)

--- a/src/S3/s3sound.c
+++ b/src/S3/s3sound.c
@@ -13,4 +13,5 @@ void S3StopAllOutletSounds() {
 }
 
 tS3_sound_tag S3StartSound(tS3_outlet_ptr pOutlet, tS3_sound_id pSound) {
+    return 0;
 }

--- a/src/harness/CMakeLists.txt
+++ b/src/harness/CMakeLists.txt
@@ -12,9 +12,10 @@ target_link_libraries(harness PRIVATE miniposix SDL2::SDL2 glad)
 if(NOT MSVC)
     target_compile_options(harness PRIVATE
         -g
-        -Wno-return-type
-        -Wno-missing-declarations
-        -Werror=implicit-function-declaration
+        -Wall
+        -Wextra
+        -Werror
+        -Wno-unused-parameter
     )
 else()
     target_compile_definitions(harness PRIVATE -D_CRT_SECURE_NO_WARNINGS)

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -130,7 +130,6 @@ void Harness_RenderScreen(br_pixelmap* dst, br_pixelmap* src) {
     if (screen_buffer == NULL) {
         screen_buffer = malloc(src->width * src->height * sizeof(uint32_t));
     }
-    memset(screen_buffer, 0, src->width * src->height * sizeof(uint32_t));
 
     // generate 32 bit texture from src + palette
     for (y = 0; y < src->height; y++) {

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -130,17 +130,15 @@ void Harness_RenderScreen(br_pixelmap* dst, br_pixelmap* src) {
 
     if (screen_buffer == NULL) {
         screen_buffer = malloc(src->width * src->height * sizeof(uint32_t));
-        memset(screen_buffer, 0, src->width * src->height * sizeof(uint32_t));
     }
+    memset(screen_buffer, 0, src->width * src->height * sizeof(uint32_t));
 
     // generate 32 bit texture from src + palette
     for (y = 0; y < src->height; y++) {
         inc = 0;
         for (x = 0; x < src->width; x++) {
-
             palette_index = (data[y * src->row_bytes + x]);
-            true_color = colors[palette_index];
-            screen_buffer[y * src->width + x] = true_color;
+            screen_buffer[y * src->width + x] = colors[palette_index];
         }
     }
     current_renderer->doubleBuffer(screen_buffer, window);

--- a/src/harness/harness.c
+++ b/src/harness/harness.c
@@ -124,7 +124,6 @@ void Harness_RenderScreen(br_pixelmap* dst, br_pixelmap* src) {
     int inc = 0;
     uint8_t* data = src->pixels;
     uint32_t* colors = palette->pixels;
-    uint32_t true_color;
     int x;
     int y;
 

--- a/src/harness/harness.h
+++ b/src/harness/harness.h
@@ -10,6 +10,8 @@
 typedef struct tRenderer {
     int (*get_window_flags)();
     void (*init)(SDL_Window* window);
+    void (*renderFrameBegin)();
+    void (*renderFrameEnd)();
     void (*doubleBuffer)(uint32_t* src, SDL_Window* window);
 } tRenderer;
 

--- a/src/harness/renderers/gl_renderer.c
+++ b/src/harness/renderers/gl_renderer.c
@@ -79,7 +79,7 @@ void Harness_GLRenderer_Init(SDL_Window* window) {
                             "   TexCoord = aTexCoord;\n"
                             "}\0";
     const char* fs_source = "#version 330 core\n"
-                            "layout(location = 0) out vec4 FragColor;\n"
+                            "out vec4 FragColor;\n"
                             "in vec2 TexCoord;\n"
                             "uniform sampler2D ourTexture;\n"
 

--- a/src/harness/renderers/gl_renderer.c
+++ b/src/harness/renderers/gl_renderer.c
@@ -4,7 +4,9 @@
 /*
 #ifdef _WIN32
 #include <windows.h>
+
 #include <gl/gl.h>
+
 #elif defined __unix__
 #define GL_GLEXT_PROTOTYPES 1
 #include <GL/gl.h>
@@ -13,13 +15,17 @@
 #include <OpenGL/gl3.h>
 #endif
 */
+
 #include <glad/glad.h>
+
 #include <SDL_opengl.h>
 
 tRenderer OpenGLRenderer = {
     Harness_GLRenderer_GetWindowFlags,
     Harness_GLRenderer_Init,
-    Harness_GLRenderer_DoubleBuffer,
+    Harness_GLRenderer_RenderFrameBegin,
+    Harness_GLRenderer_RenderFrameEnd,
+    Harness_GLRenderer_DoubleBuffer
 };
 
 SDL_GLContext context;
@@ -73,7 +79,7 @@ void Harness_GLRenderer_Init(SDL_Window* window) {
                             "   TexCoord = aTexCoord;\n"
                             "}\0";
     const char* fs_source = "#version 330 core\n"
-                            "out vec4 FragColor;\n"
+                            "layout(location = 0) out vec4 FragColor;\n"
                             "in vec2 TexCoord;\n"
                             "uniform sampler2D ourTexture;\n"
 
@@ -130,6 +136,12 @@ void Harness_GLRenderer_Init(SDL_Window* window) {
     glGenTextures(1, &screen_texture);
 }
 
+void Harness_GLRenderer_RenderFrameBegin() {
+}
+
+void Harness_GLRenderer_RenderFrameEnd() {
+}
+
 void Harness_GLRenderer_DoubleBuffer(uint32_t* screen_buffer, SDL_Window* window) {
 
     glBindTexture(GL_TEXTURE_2D, screen_texture);
@@ -139,7 +151,7 @@ void Harness_GLRenderer_DoubleBuffer(uint32_t* screen_buffer, SDL_Window* window
     // TODO: remove fixed 320x200
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 320, 200, 0, GL_BGRA, GL_UNSIGNED_BYTE, screen_buffer);
 
-    glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
+    glClearColor(0.0f, 0.0f, 0.3f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
     glUseProgram(shader_program);

--- a/src/harness/renderers/gl_renderer.h
+++ b/src/harness/renderers/gl_renderer.h
@@ -9,6 +9,10 @@ extern tRenderer OpenGLRenderer;
 int Harness_GLRenderer_GetWindowFlags();
 void Harness_GLRenderer_Init(SDL_Window* window);
 void Harness_GLRenderer_Activate(SDL_Window* window);
+
+void Harness_GLRenderer_RenderFrameBegin();
+void Harness_GLRenderer_RenderFrameEnd();
+
 void Harness_GLRenderer_DoubleBuffer(uint32_t* dst, SDL_Window* window);
 
 #endif

--- a/src/harness/renderers/null_renderer.c
+++ b/src/harness/renderers/null_renderer.c
@@ -7,8 +7,16 @@ void Harness_NullRenderer_Init(SDL_Window* window) {}
 void Harness_NullRenderer_Activate(SDL_Window* window) {}
 void Harness_NullRenderer_DoubleBuffer(uint32_t* src, SDL_Window* window) {}
 
+void Harness_NullRenderer_RenderFrameBegin() {
+}
+
+void Harness_NullRenderer_RenderFrameEnd() {
+}
+
 tRenderer NullRenderer = {
     Harness_NullRenderer_GetWindowFlags,
     Harness_NullRenderer_Init,
+    Harness_NullRenderer_RenderFrameBegin,
+    Harness_NullRenderer_RenderFrameEnd,
     Harness_NullRenderer_DoubleBuffer
 };

--- a/src/harness/stack_trace_handler.h
+++ b/src/harness/stack_trace_handler.h
@@ -270,8 +270,6 @@ void posix_signal_handler(int sig, siginfo_t* siginfo, void* context) {
 static uint8_t alternate_stack[SIGSTKSZ];
 
 void resolve_full_path(char* path, const char* argv0) {
-    char buf[PATH_MAX];
-    char* pos;
     if (argv0[0] == '/') { // run with absolute path
         strcpy(path, argv0);
     } else { // run with relative path


### PR DESCRIPTION
Adds `-Wall -Wextra -Werror` to all build dirs
Fixes `CleverText*` headup rendering by encoding extended ASCII chars as literals to avoid being turned into UTF-8